### PR TITLE
fix:select-routing

### DIFF
--- a/app/[locale]/profile/client-utils.tsx
+++ b/app/[locale]/profile/client-utils.tsx
@@ -110,10 +110,7 @@ export const Tabs = ({
   ];
 
   return select ? (
-    <Select
-      onValueChange={(value) => router.push(`/${locale}/profile/${value}`)}
-      defaultValue={tab}
-    >
+    <Select defaultValue={tab} navigate>
       <SelectTrigger className="w-[180px] px-4 py-5 text-shade-light md:hidden">
         <SelectValue />
       </SelectTrigger>

--- a/components/inputs/select.tsx
+++ b/components/inputs/select.tsx
@@ -2,6 +2,7 @@
 
 import * as SelectPrimitive from '@radix-ui/react-select';
 import { cva } from 'class-variance-authority';
+import { useRouter } from 'next/navigation';
 import * as React from 'react';
 import { RxCheck, RxChevronDown, RxChevronUp } from 'react-icons/rx';
 
@@ -24,14 +25,25 @@ function useSelect() {
 }
 
 const Select = ({
+  navigate = false,
+  onValueChange,
   variant = 'ui',
   ...props
 }: React.ComponentPropsWithoutRef<typeof SelectPrimitive.Root> & {
+  navigate?: boolean;
   variant?: 'form' | 'ui';
 }) => {
+  const router = useRouter();
+
   return (
     <SelectContext.Provider value={{ variant }}>
-      <SelectPrimitive.Root {...props} />
+      <SelectPrimitive.Root
+        onValueChange={(value) => {
+          navigate && router.push(value);
+          onValueChange && onValueChange(value);
+        }}
+        {...props}
+      />
     </SelectContext.Provider>
   );
 };


### PR DESCRIPTION
Because of how select components functions, child click events arent accepted, modified to add navigation to the component.
made variant compulsory so that path is always mentioned.