### PR TITLE
fix: category field for section heads

### DIFF
--- a/server/db/schema/section-heads.schema.ts
+++ b/server/db/schema/section-heads.schema.ts
@@ -13,6 +13,7 @@ export const sectionHeads = pgTable('section_head_faculty', (t) => ({
     .integer()
     .references(() => faculty.id)
     .notNull(),
+  category: t.varchar().notNull(),
 }));
 
 export const sectionHeadFacultyRelations = relations(


### PR DESCRIPTION
For example: head, associate-head, <sports-type> etc.