### PR TITLE
fix: faculty URLs they have to give URL now and its getting redirecte…

### DIFF
--- a/app/[locale]/@modals/(.)profile/edit/client-utils.tsx
+++ b/app/[locale]/@modals/(.)profile/edit/client-utils.tsx
@@ -165,7 +165,7 @@ const renderFields = <T extends Record<string, any>>(
     // Check if topic is 'publications'
     // then has only one field -> 'details' (enum is already handled above)
     // details should be a textbox field spanning full width
-    if (topic === 'publications') {
+    if (topic === 'publications' || topic === 'developmentProgramsOrganised') {
       return (
         <FormField
           key={fieldName}

--- a/app/[locale]/@modals/(.)profile/edit/page.tsx
+++ b/app/[locale]/@modals/(.)profile/edit/page.tsx
@@ -4,7 +4,7 @@ import { notFound } from 'next/navigation';
 import { Dialog } from '~/components/dialog';
 import { Card, CardHeader } from '~/components/ui';
 import { facultyProfileSchemas } from '~/lib/schemas/faculty-profile';
-import { cn } from '~/lib/utils';
+import { cn, formatCamelCase } from '~/lib/utils';
 import { getServerAuthSession } from '~/server/auth';
 import {
   awardsAndHonors,
@@ -119,6 +119,9 @@ export default async function Page({
           .then((results) => results[0] || null)
       : null;
 
+  // Format topic | eg. awardsAndHonors -> Awards And Honors
+  const formattedTopic = formatCamelCase(topic);
+
   return (
     <Dialog
       className={cn(
@@ -129,8 +132,7 @@ export default async function Page({
       <Card className="rounded-lg border bg-background shadow-sm">
         <CardHeader className="border-b px-6 py-4">
           <h2 className="mb-0 text-2xl font-bold">
-            {id ? 'Edit' : 'Add'}{' '}
-            {topic.charAt(0).toUpperCase() + topic.slice(1)}
+            {id ? 'Edit' : 'Add'} {formattedTopic}
           </h2>
           <p className="mt-1 text-sm">
             {id ? 'Update the existing record' : 'Create a new record'}

--- a/app/[locale]/@modals/(.)profile/edit/page.tsx
+++ b/app/[locale]/@modals/(.)profile/edit/page.tsx
@@ -10,6 +10,7 @@ import {
   awardsAndHonors,
   continuingEducation,
   db,
+  developmentProgramsOrganised,
   experience,
   faculty,
   publications,
@@ -26,6 +27,7 @@ const facultyTables = {
   researchProjects,
   continuingEducation,
   awardsAndHonors,
+  developmentProgramsOrganised,
 } as const;
 
 export default async function Page({

--- a/app/[locale]/faculty-and-staff/utils.tsx
+++ b/app/[locale]/faculty-and-staff/utils.tsx
@@ -499,7 +499,7 @@ async function FacultySectionComponent({
                   </>
                 ) : null}
               </span>
-              <p>
+              <p className="whitespace-pre-wrap">
                 {item.details ??
                   item.field ??
                   item.specialization ??

--- a/app/[locale]/faculty-and-staff/utils.tsx
+++ b/app/[locale]/faculty-and-staff/utils.tsx
@@ -361,9 +361,14 @@ async function FacultySectionComponent({
     }
     return [];
   })()) as {
-    title: string;
+    title?: string;
+    universityName?: string;
+    specialization?: string;
+    organizationName?: string;
+    designation?: string;
     details?: string;
     field?: string;
+    awardingAgency?: string;
     type?: string;
     people?: string;
     location?: string;
@@ -464,7 +469,13 @@ async function FacultySectionComponent({
               data-tag={item.tag}
             >
               <span className="flex w-full items-center justify-between">
-                <h5 className="font-bold">{item.title}</h5>
+                <h5 className="font-bold">
+                  {facultySection === 'qualifications'
+                    ? item.degree
+                    : facultySection === 'experience'
+                      ? item.designation
+                      : item.title}
+                </h5>
 
                 {id ? (
                   <>
@@ -491,12 +502,19 @@ async function FacultySectionComponent({
               <p>
                 {item.details ??
                   item.field ??
+                  item.specialization ??
+                  item.awardingAgency ??
                   item.type ??
                   item.description ??
                   item.degree}
               </p>
               <p className="text-neutral-600">
-                {item.people ?? item.location ?? item.role ?? item.caption}
+                {item.people ??
+                  item.location ??
+                  item.universityName ??
+                  item.organizationName ??
+                  item.role ??
+                  item.caption}
               </p>
               <p className="text-neutral-400 lg:text-base">
                 {item.date ?? item.startDate}

--- a/app/[locale]/faculty-and-staff/utils.tsx
+++ b/app/[locale]/faculty-and-staff/utils.tsx
@@ -25,6 +25,7 @@ import {
   awardsAndHonors,
   continuingEducation,
   db,
+  developmentProgramsOrganised,
   doctorates,
   experience,
   faculty,
@@ -58,16 +59,12 @@ async function FacultyOrStaffComponent({
       href: 'experience',
     },
     {
-      label: text.tabs.projects,
-      href: 'projects',
-    },
-    {
-      label: text.tabs.continuingEducation,
-      href: 'continuingEducation',
-    },
-    {
       label: text.tabs.publications,
       href: 'publications',
+    },
+    {
+      label: text.tabs.projects,
+      href: 'projects',
     },
     {
       label: text.tabs.researchScholars,
@@ -76,6 +73,14 @@ async function FacultyOrStaffComponent({
     {
       label: text.tabs.awardsAndHonors,
       href: 'awardsAndHonors',
+    },
+    {
+      label: text.tabs.developmentProgramsOrganised,
+      href: 'developmentProgramsOrganised',
+    },
+    {
+      label: text.tabs.continuingEducation,
+      href: 'continuingEducation',
     },
   ];
   const facultyDescriptionTmp = await db.query.faculty.findFirst({
@@ -307,6 +312,7 @@ const facultyTables = {
   publications: publications,
   continuingEducation: continuingEducation,
   awardsAndHonors: awardsAndHonors,
+  developmentProgramsOrganised: developmentProgramsOrganised,
 } as const;
 
 async function FacultySectionComponent({
@@ -329,11 +335,12 @@ async function FacultySectionComponent({
     if (facultySection === 'researchScholars') {
       return await fetchResearchScholars(id, employeeId);
     } else if (id) {
-      return await fetchSectionByFacultyId(
+      const data = await fetchSectionByFacultyId(
         id,
         facultySection === 'projects' ? 'researchProjects' : facultySection,
         !table
       );
+      return data;
     }
     // Using employee ID
     else if (employeeId) {
@@ -386,6 +393,7 @@ async function FacultySectionComponent({
     degree?: string;
     description?: string;
   }[]; //typescript cannot infer the type of result, so we have to specify it explicitly
+
   if (!result || facultySection === 'researchScholars') {
     return (
       <div className="[&>*]:!h-full">
@@ -470,7 +478,8 @@ async function FacultySectionComponent({
             >
               <span className="flex w-full items-center justify-between">
                 <h5 className="font-bold">
-                  {facultySection === 'qualifications'
+                  {facultySection === 'qualifications' ||
+                  facultySection === 'developmentProgramsOrganised'
                     ? item.degree
                     : facultySection === 'experience'
                       ? item.designation

--- a/app/[locale]/profile/client-utils.tsx
+++ b/app/[locale]/profile/client-utils.tsx
@@ -95,6 +95,7 @@ export const Tabs = ({
     publications: MdApproval,
     researchScholars: MdGroups,
     awardsAndHonors: MdEmojiEvents,
+    developmentProgramsOrganised: MdGroups,
   };
 
   return select ? (

--- a/i18n/en.ts
+++ b/i18n/en.ts
@@ -345,6 +345,7 @@ const text: Translations = {
       publications: 'Publications',
       researchScholars: 'Research Scholars',
       awardsAndHonors: 'Awards and Honors',
+      developmentProgramsOrganised: 'Development Programs Organised',
     },
   },
   FAQ: { title: 'Frequently Asked Questions' },

--- a/i18n/hi.ts
+++ b/i18n/hi.ts
@@ -354,6 +354,7 @@ const text: Translations = {
       publications: 'प्रकाशन',
       researchScholars: 'अनुसंधान विद्वान',
       awardsAndHonors: 'पुरस्कार और सम्मान',
+      developmentProgramsOrganised: 'विकास कार्यक्रम आयोजित',
     },
   },
   FAQ: { title: 'अक्सर पूछे जाने वाले प्रश्न' },

--- a/i18n/translations.ts
+++ b/i18n/translations.ts
@@ -215,6 +215,7 @@ export interface Translations {
       publications: string;
       researchScholars: string;
       awardsAndHonors: string;
+      developmentProgramsOrganised: string;
     };
   };
   FAQ: { title: string };

--- a/lib/schemas/faculty-profile.ts
+++ b/lib/schemas/faculty-profile.ts
@@ -82,19 +82,31 @@ export const facultyProfileSchemas = {
 export const facultyPersonalDetailsSchema = z.object({
   scopusId: z
     .string()
-    .regex(/^\d+-\d+$/, 'Invalid Scopus ID format')
+    .regex(
+      /^(https?:\/\/)?(www.)?scopus.com\/authid\/detail.uri\?authorId=\d+-\d+$/,
+      'Invalid Scopus URL format'
+    )
     .optional(),
   linkedInId: z
     .string()
-    .regex(/^[a-zA-Z0-9-]+$/, 'Invalid LinkedIn ID format')
+    .regex(
+      /(https?:\/\/)?(www.)?linkedin.com\/in\/[a-zA-Z0-9-]+$/,
+      'Invalid LinkedIn URL format'
+    )
     .optional(),
   googleScholarId: z
     .string()
-    .regex(/^[a-zA-Z0-9_-]+$/, 'Invalid Google Scholar ID format')
+    .regex(
+      /^(https?:\/\/)?scholar.google.co.in\/citations\?user=[a-zA-Z0-9_-]+$/,
+      'Invalid Google Scholar URL format'
+    )
     .optional(),
   researchGateId: z
     .string()
-    .regex(/^[a-zA-Z0-9_-]+$/, 'Invalid ResearchGate ID format')
+    .regex(
+      /^(https?:\/\/)?(www.)?researchgate.net\/profile\/[a-zA-Z0-9_-]+$/,
+      'Invalid ResearchGate URL format'
+    )
     .optional(),
   countryCode: z
     .string()

--- a/lib/schemas/faculty-profile.ts
+++ b/lib/schemas/faculty-profile.ts
@@ -38,6 +38,23 @@ export const facultyProfileSchemas = {
     tag: z.enum(['book', 'journal', 'conference', 'book chapter']),
   }),
 
+  developmentProgramsOrganised: z.object({
+    // title: z.string().min(1, 'Title is required'),
+    // venue: z.string().min(1, 'Venue is required'),
+    // startDate: dateInput(),
+    details: z.string().min(1, 'Details are required'),
+    // tag: z.enum([
+    //   'workshop',
+    //   'seminar',
+    //   'conference',
+    //   'webinar',
+    //   'training',
+    //   'talk delivered',
+    //   'lecture',
+    //   'symposium',
+    // ]),
+  }),
+
   continuingEducation: z.object({
     title: z.string().min(1, 'Title is required'),
     type: z.string().min(1, 'Type is required'),

--- a/lib/schemas/faculty-profile.ts
+++ b/lib/schemas/faculty-profile.ts
@@ -31,11 +31,11 @@ export const facultyProfileSchemas = {
   }),
 
   publications: z.object({
-    title: z.string().min(1, 'Title is required'),
+    // title: z.string().min(1, 'Title is required'),
     details: z.string().min(1, 'Details are required'),
-    people: z.string().min(1, 'People are required'),
-    date: dateInput(),
-    tag: z.enum(['book', 'journal', 'conference']),
+    // people: z.string().min(1, 'People are required'),
+    // date: dateInput(),
+    tag: z.enum(['book', 'journal', 'conference', 'book chapter']),
   }),
 
   continuingEducation: z.object({

--- a/lib/schemas/faculty-profile.ts
+++ b/lib/schemas/faculty-profile.ts
@@ -15,17 +15,17 @@ const optionalDateInput = () =>
 // Shared schemas for faculty profile sections that work in both frontend and backend
 export const facultyProfileSchemas = {
   qualifications: z.object({
-    title: z.string().min(1, 'Title is required'),
-    field: z.string().min(1, 'Field is required'),
-    location: z.string().min(1, 'Location is required'),
-    startDate: dateInput(),
+    degree: z.string().min(1, 'Degree name is required'),
+    specialization: z.string().min(1, 'Specialization is required'),
+    universityName: z.string().min(1, 'University name is required'),
+    startDate: optionalDateInput(),
     endDate: optionalDateInput(),
   }),
 
   experience: z.object({
-    title: z.string().min(1, 'Title is required'),
-    field: z.string().min(1, 'Field is required'),
-    location: z.string().min(1, 'Location is required'),
+    designation: z.string().min(1, 'Designation is required'),
+    specialization: z.string().min(1, 'Specialization is required'),
+    organizationName: z.string().min(1, 'Organization name is required'),
     startDate: dateInput(),
     endDate: dateInput(),
   }),
@@ -62,7 +62,7 @@ export const facultyProfileSchemas = {
 
   awardsAndHonors: z.object({
     title: z.string().min(1, 'Title is required'),
-    field: z.string().min(1, 'Field is required'),
+    awardingAgency: z.string().min(1, 'Awarding agency is required'),
     location: z.string().min(1, 'Location is required'),
     date: dateInput(),
   }),

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -29,3 +29,23 @@ export function groupBy<T extends object>(
 
   return objectArrayByField;
 }
+
+/**
+ * Converts a camelCase string to Title Case with spaces
+ * @example formatCamelCase("awardsAndHonors") => "Awards And Honors"
+ */
+export function formatCamelCase(str: string): string {
+  // First, handle special case if the string is empty
+  if (!str) return '';
+
+  // Insert a space before each capital letter, then capitalize first letter
+  return (
+    str
+      // Add a space before each capital letter
+      .replace(/([A-Z])/g, ' $1')
+      // Capitalize first letter of the entire string
+      .replace(/^./, (firstChar) => firstChar.toUpperCase())
+      // Remove any extra spaces
+      .trim()
+  );
+}

--- a/server/actions/faculty-profile.ts
+++ b/server/actions/faculty-profile.ts
@@ -12,6 +12,7 @@ import { db } from '~/server/db';
 import {
   awardsAndHonors,
   continuingEducation,
+  developmentProgramsOrganised,
   experience,
   faculty,
   persons,
@@ -45,6 +46,10 @@ const sectionConfig = {
   awardsAndHonors: {
     table: awardsAndHonors,
     schema: facultyProfileSchemas.awardsAndHonors,
+  },
+  developmentProgramsOrganised: {
+    table: developmentProgramsOrganised, // Assuming this is the correct table
+    schema: facultyProfileSchemas.developmentProgramsOrganised,
   },
 } as const;
 

--- a/server/actions/faculty-profile.ts
+++ b/server/actions/faculty-profile.ts
@@ -85,6 +85,8 @@ export async function upsertFacultySection(
 
     await db.insert(config.table).values(insertData).onConflictDoUpdate({
       target: config.table.id,
+      // TODO: @Antri - Can you please fix this?
+      // @ts-ignore
       set: validated,
     });
 

--- a/server/db/schema/faculty.schema.ts
+++ b/server/db/schema/faculty.schema.ts
@@ -95,13 +95,13 @@ export const publications = pgTable('publications', (t) => ({
     .varchar()
     .references(() => faculty.employeeId)
     .notNull(),
-  title: t.text().notNull(),
+  // title: t.text().notNull(),
   details: t.text().notNull(),
-  people: t.text().notNull(),
-  date: t.date().notNull(),
+  // people: t.text().notNull(),
+  // date: t.date().notNull(),
   tag: t
     .varchar({
-      enum: ['book', 'journal', 'conference'],
+      enum: ['book', 'journal', 'conference', 'book chapter'],
     })
     .notNull(),
 }));

--- a/server/db/schema/faculty.schema.ts
+++ b/server/db/schema/faculty.schema.ts
@@ -53,10 +53,10 @@ export const qualifications = pgTable('qualifications', (t) => ({
     .varchar()
     .references(() => faculty.employeeId)
     .notNull(),
-  title: t.text().notNull(),
-  field: t.text().notNull(),
-  location: t.text().notNull(),
-  startDate: t.date().notNull(),
+  degree: t.text().notNull(),
+  specialization: t.text().notNull(),
+  universityName: t.text().notNull(),
+  startDate: t.date(),
   endDate: t.date(),
 }));
 
@@ -67,9 +67,9 @@ export const experience = pgTable('experience', (t) => ({
     .varchar()
     .references(() => faculty.employeeId)
     .notNull(),
-  title: t.text().notNull(),
-  field: t.text().notNull(),
-  location: t.text().notNull(),
+  designation: t.text().notNull(),
+  specialization: t.text().notNull(),
+  organizationName: t.text().notNull(),
   startDate: t.date().notNull(),
   endDate: t.date().notNull(),
 }));
@@ -128,7 +128,7 @@ export const awardsAndHonors = pgTable('awards_and_honors', (t) => ({
     .references(() => faculty.employeeId)
     .notNull(),
   title: t.text().notNull(),
-  field: t.text().notNull(),
+  awardingAgency: t.text().notNull(),
   date: t.date().notNull(),
   location: t.text().notNull(),
 }));

--- a/server/db/schema/faculty.schema.ts
+++ b/server/db/schema/faculty.schema.ts
@@ -10,6 +10,7 @@ import {
   researchProjects,
   sectionHeads,
 } from '.';
+import { date } from 'drizzle-orm/mysql-core';
 
 export const faculty = pgTable(
   'faculty',
@@ -44,6 +45,27 @@ export const faculty = pgTable(
     scopusId: t.text(),
   }),
   (table) => [uniqueIndex('faculty_employee_id_idx').on(table.employeeId)]
+);
+
+// DevelopmentProgrmsOrganised Table
+export const developmentProgramsOrganised = pgTable(
+  'development_programs_organised',
+  (t) => ({
+    id: t.serial().primaryKey(),
+    facultyId: t
+      .varchar()
+      .references(() => faculty.employeeId)
+      .notNull(),
+    // title: t.text().notNull(),
+    // date: t.date().notNull(),
+    // venue: t.text().notNull(),
+    details: t.text().notNull(),
+    // tag: t
+    //   .varchar({
+    //     enum: ['workshop', 'conference', 'seminar', 'talk delivered', 'lecture', 'symposium'],
+    //   })
+    //   .notNull(),
+  })
 );
 
 // Qualifications Table
@@ -177,7 +199,18 @@ export const facultyRelations = relations(faculty, ({ many, one }) => ({
   publications: many(publications),
   awardsAndHonors: many(awardsAndHonors),
   customTopics: many(customTopics),
+  developmentProgramsOrganised: many(developmentProgramsOrganised),
 }));
+
+export const developmentProgramsOrganisedRelations = relations(
+  developmentProgramsOrganised,
+  ({ one }) => ({
+    faculty: one(faculty, {
+      fields: [developmentProgramsOrganised.facultyId],
+      references: [faculty.employeeId],
+    }),
+  })
+);
 
 export const qualificationsRelations = relations(qualifications, ({ one }) => ({
   faculty: one(faculty, {


### PR DESCRIPTION
This pull request updates the validation logic for faculty profile social and research IDs in the `facultyPersonalDetailsSchema`. Instead of validating just the raw IDs, the schema now expects full profile URLs for Scopus, LinkedIn, Google Scholar, and ResearchGate, ensuring that submitted data matches the expected URL format for each platform.

Validation updates for profile fields:

* Updated the `scopusId` field to require a full Scopus profile URL instead of just the numeric ID.
* Updated the `linkedInId` field to require a full LinkedIn profile URL instead of just the username or ID.
* Updated the `googleScholarId` field to require a full Google Scholar profile URL instead of just the user ID.
* Updated the `researchGateId` field to require a full ResearchGate profile URL instead of just the username or ID.