### PR TITLE
feat: added tags in Awards and Recognition

### DIFF
--- a/i18n/en.ts
+++ b/i18n/en.ts
@@ -336,6 +336,8 @@ const text: Translations = {
       chapter: 'Chapter',
       journal: 'Journal',
       conference: 'Conference',
+      award: 'Award',
+      recognition:'Recognition'
     },
     tabs: {
       qualifications: 'Education Qualifications',

--- a/i18n/hi.ts
+++ b/i18n/hi.ts
@@ -345,6 +345,8 @@ const text: Translations = {
       journal: 'जर्नल',
       chapter: 'अध्याय',
       conference: 'सम्मेलन',
+      award: 'पुरस्कार',
+      recognition: 'मान्यता'
     },
     tabs: {
       qualifications: 'शैक्षिक योग्यता',

--- a/i18n/translations.ts
+++ b/i18n/translations.ts
@@ -206,6 +206,8 @@ export interface Translations {
       chapter: string;
       journal: string;
       conference: string;
+      award: string;
+      recognition : string;
     };
     tabs: {
       qualifications: string;

--- a/lib/schemas/faculty-profile.ts
+++ b/lib/schemas/faculty-profile.ts
@@ -94,6 +94,7 @@ export const facultyProfileSchemas = {
     awardingAgency: z.string().min(1, 'Awarding agency is required'),
     location: z.string().min(1, 'Location is required'),
     date: dateInput(),
+    tag: z.enum(['award','recognition']),
   }),
 
   customTopics: z.object({

--- a/lib/schemas/faculty-profile.ts
+++ b/lib/schemas/faculty-profile.ts
@@ -94,7 +94,7 @@ export const facultyProfileSchemas = {
     awardingAgency: z.string().min(1, 'Awarding agency is required'),
     location: z.string().min(1, 'Location is required'),
     date: dateInput(),
-    tag: z.enum(['award','recognition']),
+    tag: z.enum(['award', 'recognition']),
   }),
 
   customTopics: z.object({

--- a/server/db/schema/faculty.schema.ts
+++ b/server/db/schema/faculty.schema.ts
@@ -183,6 +183,11 @@ export const awardsAndRecognitions = pgTable(
     awardingAgency: t.text().notNull(),
     date: t.date().notNull(),
     location: t.text().notNull(),
+    tag: t
+    .varchar({
+      enum: ['award','recognition'],
+    })
+    .notNull(),
   })
 );
 

--- a/server/db/schema/faculty.schema.ts
+++ b/server/db/schema/faculty.schema.ts
@@ -185,7 +185,7 @@ export const awardsAndRecognitions = pgTable(
     location: t.text().notNull(),
     tag: t
     .varchar({
-      enum: ['award','recognition'],
+      enum: ['award', 'recognition'],
     })
     .notNull(),
   })


### PR DESCRIPTION
This pull request adds support for distinguishing between "award" and "recognition" in faculty profiles, including updates to translations, schema validation, and the database schema. The main changes are grouped below:

**Internationalization updates:**

* Added "award" and "recognition" fields to the English (`i18n/en.ts`) and Hindi (`i18n/hi.ts`) translation files. [[1]](diffhunk://#diff-8ee4c65eaaf735c33bd37bf76d2a87fb76d02b7928096cc26db6364694988ceeR339-R340) [[2]](diffhunk://#diff-912c4f60653cc2c8d00fda0b21a7a65ab1c3e1c3f65007e1f211f40c951596b8R348-R349)
* Updated the `Translations` interface to include `award` and `recognition` fields.

**Schema and database updates:**

* Updated the faculty profile schema to require a `tag` field, which must be either "award" or "recognition".
* Modified the `awardsAndRecognitions` database table to include a `tag` column with allowed values "award" or "recognition".