### PR TITLE
Feat/tags/ipr

### DIFF
--- a/i18n/en.ts
+++ b/i18n/en.ts
@@ -336,6 +336,8 @@ const text: Translations = {
       chapter: 'Chapter',
       journal: 'Journal',
       conference: 'Conference',
+      award: 'Award',
+      recognition:'Recognition'
     },
     tabs: {
       qualifications: 'Education Qualifications',

--- a/i18n/en.ts
+++ b/i18n/en.ts
@@ -337,7 +337,11 @@ const text: Translations = {
       journal: 'Journal',
       conference: 'Conference',
       award: 'Award',
-      recognition:'Recognition'
+      recognition:'Recognition',
+      patent:'Patent',
+      design:'Design',
+      copyright:'Copyright',
+      trademark:'Trademark'
     },
     tabs: {
       qualifications: 'Education Qualifications',

--- a/i18n/hi.ts
+++ b/i18n/hi.ts
@@ -345,6 +345,8 @@ const text: Translations = {
       journal: 'जर्नल',
       chapter: 'अध्याय',
       conference: 'सम्मेलन',
+      award: 'पुरस्कार',
+      recognition: 'मान्यता'
     },
     tabs: {
       qualifications: 'शैक्षिक योग्यता',

--- a/i18n/hi.ts
+++ b/i18n/hi.ts
@@ -346,7 +346,11 @@ const text: Translations = {
       chapter: 'अध्याय',
       conference: 'सम्मेलन',
       award: 'पुरस्कार',
-      recognition: 'मान्यता'
+      recognition: 'मान्यता',
+      patent: 'पेटेंट',
+      design: 'डिज़ाइन',
+      trademark: 'ट्रेडमार्क',
+      copyright: 'कॉपीराइट'
     },
     tabs: {
       qualifications: 'शैक्षिक योग्यता',

--- a/i18n/translations.ts
+++ b/i18n/translations.ts
@@ -206,6 +206,8 @@ export interface Translations {
       chapter: string;
       journal: string;
       conference: string;
+      award: string;
+      recognition : string;
     };
     tabs: {
       qualifications: string;

--- a/i18n/translations.ts
+++ b/i18n/translations.ts
@@ -208,6 +208,10 @@ export interface Translations {
       conference: string;
       award: string;
       recognition : string;
+      patent: string;
+      design: string;
+      trademark: string;
+      copyright: string;
     };
     tabs: {
       qualifications: string;

--- a/lib/schemas/faculty-profile.ts
+++ b/lib/schemas/faculty-profile.ts
@@ -58,7 +58,7 @@ export const facultyProfileSchemas = {
   ipr: z.object({
     details: z.string().min(1, 'Details are required'),
     // date: dateInput(),
-    // tag: z.enum(['patent', 'copyright', 'trademark', 'design']),
+    tag: z.enum(['patent', 'copyright', 'trademark', 'design']),
   }),
 
   outreachActivities: z.object({

--- a/lib/schemas/faculty-profile.ts
+++ b/lib/schemas/faculty-profile.ts
@@ -94,6 +94,7 @@ export const facultyProfileSchemas = {
     awardingAgency: z.string().min(1, 'Awarding agency is required'),
     location: z.string().min(1, 'Location is required'),
     date: dateInput(),
+    tag: z.enum(['award','recognition']),
   }),
 
   customTopics: z.object({

--- a/server/db/schema/faculty.schema.ts
+++ b/server/db/schema/faculty.schema.ts
@@ -56,11 +56,11 @@ export const ipr = pgTable('ipr', (t) => ({
   // title: t.text().notNull(),
   details: t.text().notNull(),
   // date: t.date().notNull(),
-  // tag: t
-  //   .varchar({
-  //     enum: ['patent', 'copyright', 'trademark', 'design'],
-  //   })
-  //   .notNull(),
+  tag: t
+    .varchar({
+      enum: ['patent', 'copyright', 'trademark', 'design'],
+    })
+    .notNull(),
 }));
 
 // Outreach Activities

--- a/server/db/schema/faculty.schema.ts
+++ b/server/db/schema/faculty.schema.ts
@@ -183,6 +183,11 @@ export const awardsAndRecognitions = pgTable(
     awardingAgency: t.text().notNull(),
     date: t.date().notNull(),
     location: t.text().notNull(),
+    tag: t
+    .varchar({
+      enum: ['award','recognition'],
+    })
+    .notNull(),
   })
 );
 


### PR DESCRIPTION
This pull request adds support for categorizing awards, recognitions, and intellectual property rights (IPR) with specific tags across the application. The changes include updating the translation files, schema validation, and database schema to handle new tag fields for awards/recognitions and IPR entries.

**Schema and Database Updates:**

* Added a `tag` field to the IPR schema and database table, allowing values: `'patent'`, `'copyright'`, `'trademark'`, and `'design'`. [[1]](diffhunk://#diff-5c6cb934d7b7beea1934ca56e01e8750ad5068e02fb7fb9d49553169433b4df3L61-R61) [[2]](diffhunk://#diff-8bcc32dd561b4fe62d5c0f87de70181d1d472510a7d4a937e24ee17dbbec9f9dL59-R63)
* Added a `tag` field to the Awards and Recognitions schema and database table, allowing values: `'award'` and `'recognition'`. [[1]](diffhunk://#diff-5c6cb934d7b7beea1934ca56e01e8750ad5068e02fb7fb9d49553169433b4df3R97) [[2]](diffhunk://#diff-8bcc32dd561b4fe62d5c0f87de70181d1d472510a7d4a937e24ee17dbbec9f9dR186-R190)

**Internationalization (i18n) Updates:**

* Updated English (`i18n/en.ts`) and Hindi (`i18n/hi.ts`) translation files to include new tag labels for awards, recognitions, patents, designs, copyrights, and trademarks. [[1]](diffhunk://#diff-8ee4c65eaaf735c33bd37bf76d2a87fb76d02b7928096cc26db6364694988ceeR339-R344) [[2]](diffhunk://#diff-912c4f60653cc2c8d00fda0b21a7a65ab1c3e1c3f65007e1f211f40c951596b8R348-R353)
* Updated the `Translations` interface to support the new tag fields.