### PR TITLE
feat: added tags in projects-and-consultancy section

### DIFF
--- a/i18n/en.ts
+++ b/i18n/en.ts
@@ -341,7 +341,9 @@ const text: Translations = {
       patent:'Patent',
       design:'Design',
       copyright:'Copyright',
-      trademark:'Trademark'
+      trademark:'Trademark',
+      project:'Project',
+      consultancy:'Consultancy'
     },
     tabs: {
       qualifications: 'Education Qualifications',

--- a/i18n/hi.ts
+++ b/i18n/hi.ts
@@ -350,7 +350,9 @@ const text: Translations = {
       patent: 'पेटेंट',
       design: 'डिज़ाइन',
       trademark: 'ट्रेडमार्क',
-      copyright: 'कॉपीराइट'
+      copyright: 'कॉपीराइट',
+      project: 'प्रोजेक्ट्स',
+      consultancy: 'परामर्श'
     },
     tabs: {
       qualifications: 'शैक्षिक योग्यता',

--- a/i18n/translations.ts
+++ b/i18n/translations.ts
@@ -212,6 +212,8 @@ export interface Translations {
       design: string;
       trademark: string;
       copyright: string;
+      project: string;
+      consultancy: string;
     };
     tabs: {
       qualifications: string;

--- a/lib/schemas/faculty-profile.ts
+++ b/lib/schemas/faculty-profile.ts
@@ -87,6 +87,7 @@ export const facultyProfileSchemas = {
     durationPeriod: z.string().min(1, 'Duration period is required'),
     durationPeriodType: z.string().min(1, 'Duration period type is required'),
     endedOn: optionalDateInput(),
+    tag: z.enum(['project', 'consultancy']),
   }),
 
   awardsAndRecognitions: z.object({

--- a/server/db/schema/research-projects.schema.ts
+++ b/server/db/schema/research-projects.schema.ts
@@ -19,6 +19,11 @@ export const researchProjects = pgTable('research_projects', (t) => ({
   durationPeriodType: t.varchar().notNull(),
   createdOn: t.date({ mode: 'date' }).defaultNow().notNull(),
   endedOn: t.date({ mode: 'date' }),
+  tag: t
+    .varchar({
+      enum: ['project', 'consultancy'],
+    })
+    .notNull(),
 }));
 
 export const researchProjectsRelations = relations(


### PR DESCRIPTION
This pull request adds support for categorizing research projects as either "project" or "consultancy" throughout the application. It introduces new translation strings for these categories in both English and Hindi, updates the schema validation, and modifies the database schema to include a `tag` field for research projects.

**Internationalization updates:**

* Added `project` and `consultancy` translation strings to the English (`i18n/en.ts`) and Hindi (`i18n/hi.ts`) translation files. [[1]](diffhunk://#diff-8ee4c65eaaf735c33bd37bf76d2a87fb76d02b7928096cc26db6364694988ceeL344-R346) [[2]](diffhunk://#diff-912c4f60653cc2c8d00fda0b21a7a65ab1c3e1c3f65007e1f211f40c951596b8L353-R355)
* Updated the `Translations` interface to include `project` and `consultancy` fields.

**Schema and database changes:**

* Updated the `facultyProfileSchemas` validation to require a `tag` field for research projects, restricted to "project" or "consultancy".
* Modified the `research_projects` database schema to add a required `tag` column, with allowed values "project" or "consultancy".