### PR TITLE
fix: added scroll-area to filter faculty section

### DIFF
--- a/app/[locale]/faculty-and-staff/page.tsx
+++ b/app/[locale]/faculty-and-staff/page.tsx
@@ -18,6 +18,7 @@ import { NoResultStatus } from '~/components/status';
 import { getTranslations } from '~/i18n/translations';
 import { cn } from '~/lib/utils';
 import { db } from '~/server/db';
+import { ScrollArea } from '~/components/ui/scroll-area';
 
 import { ClearFiltersButton, PreserveParamsLink } from './client-components';
 
@@ -48,25 +49,27 @@ export default async function FacultyAndStaff({
           <ClearFiltersButton />
         </div>
 
-        {/* Designation Filter Box */}
-        <div className="mb-6 rounded border border-primary-100 bg-neutral-50 p-4">
-          <h3 className="mb-2 text-lg font-bold text-primary-700">
-            Designation
-          </h3>
-          <Suspense fallback={<Loading className="max-xl:hidden" />}>
-            <Designations designation={designation} />
-          </Suspense>
-        </div>
+        <ScrollArea className="h-[calc(100vh-200px)]">
+          {/* Designation Filter Box */}
+          <div className="mb-6 rounded border border-primary-100 bg-neutral-50 p-4">
+            <h3 className="mb-2 text-lg font-bold text-primary-700">
+              Designation
+            </h3>
+            <Suspense fallback={<Loading className="max-xl:hidden" />}>
+              <Designations designation={designation} />
+            </Suspense>
+          </div>
 
-        {/* Department Filter Box */}
-        <div className="mb-6 rounded border border-primary-100 bg-neutral-50 p-4">
-          <h3 className="mb-2 text-lg font-bold text-primary-700">
-            Department
-          </h3>
-          <Suspense fallback={<Loading className="max-xl:hidden" />}>
-            <Departments department={departmentName} />
-          </Suspense>
-        </div>
+          {/* Department Filter Box */}
+          <div className="mb-6 rounded border border-primary-100 bg-neutral-50 p-4">
+            <h3 className="mb-2 text-lg font-bold text-primary-700">
+              Department
+            </h3>
+            <Suspense fallback={<Loading className="max-xl:hidden" />}>
+              <Departments department={departmentName} />
+            </Suspense>
+          </div>
+        </ScrollArea>
       </search>
 
       <section className="grow space-y-6">


### PR DESCRIPTION
This pull request introduces a UI improvement to the faculty and staff page by making the filter section scrollable. The main change is the addition of a scroll area to enhance usability when the filter content exceeds the viewport height.

**UI Improvements:**

* Imported the `ScrollArea` component to enable scrollable content in the filter section. ([app/[locale]/faculty-and-staff/page.tsxR21](diffhunk://#diff-73d9b8e5183a03609e638663514db195677d4e964b2ba2898d7ad4aa250d81d6R21))
* Wrapped the filter box and department selection inside the `ScrollArea` component, ensuring the filter area remains accessible and usable even with large content. ([app/[locale]/faculty-and-staff/page.tsxR52](diffhunk://#diff-73d9b8e5183a03609e638663514db195677d4e964b2ba2898d7ad4aa250d81d6R52), [app/[locale]/faculty-and-staff/page.tsxR72](diffhunk://#diff-73d9b8e5183a03609e638663514db195677d4e964b2ba2898d7ad4aa250d81d6R72))